### PR TITLE
fix incorrect HTML table matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Use the `tidocs merge` command to access a web interface for combining multiple 
 
 ## Changelog
 
+### [1.0.7] - 2024-12-23
+
+- Fix the issue that HTML tables are incorrectly extracted when `<table>` tags appear in code blocks or plain text that is not part of actual HTML markup.
+
 ### [1.0.6] - 2024-12-21
 
 - Fix the issue that hyperlinks become broken after merging Word documents due to incorrect relationship reference handling. ([#2](https://github.com/Oreoxmt/tidocs/issues/2))


### PR DESCRIPTION
This PR fixes the parser to only replace `<table>` tags when they are part of valid HTML table structures, preserving inline `<table>` mentions in regular text and code blocks.


Previously, the parser would incorrectly replace any occurrence of `<table>` tags in regular text with a placeholder token (TIDOCS_REPLACE_TABLE_0), even when they weren't part of actual HTML table markup.

For example, this text:

```markdown
Test command <table>

Line

HTML table:

<table>
...
</table>
```

would incorrectly become:

```markdown
Test command TIDOCS_REPLACE_TABLE_0
```